### PR TITLE
Fix a bunch of issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ WIN_COMBINATIONS = [
 
 # the rest of the TicTacToe class definition
 ```
-**Note** The methods we will be decribing now have been defined in previous labs. You can copy those and paste them in this lab, and tweak them sightly to make them pass the tests.
+**Tip** The next bunch of methods we will be decribing have already been defined in previous labs. You can copy your code from those labs, paste them in this one and tweak them sightly to work with the object oriented approach to pass the tests.
 
 #### `#display_board`
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ Build a method `#turn` to encapsulate the logic of a single complete turn compos
 
 1. Asking the user for their move by position 1-9.
 2. Receiving the user input.
-3. If the move is valid, make the move.
+3. If the move is valid, make the move and display the board
 4. If the move is invalid, ask for a new move until a valid move is received.
-5. Display the board after the valid move has been made.
 
 All these procedures will be wrapped into our `#turn` method. However, the majority of the logic for these procedures will be defined and encapsulated in individual methods which you've already built.
 
@@ -130,10 +129,10 @@ ask for input
 get input
 if input is valid
   make the move for input
+  show the board
 else
   ask for input again until you get a valid input
 end
-show the board
 ```
 
 #### `#turn_count`

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Your `#move` method must take in two arguments, the location in the board array 
 
 #### `#position_taken?`
 
-The `#position_taken?` method will be responsible for evaluating the user's input against the Tic Tac Toe board and checking to see whether or not that position is occupied. If the user inputs that they would like to fill out position `2`, our `#position_taken?` method will check to see if that position is vacant or if it contains an "X" or and "O". If the position is free, the method should return `false` (i.e. "not taken"), otherwise it will return `true`.
+The `#position_taken?` method will be responsible for evaluating the user's input against the Tic Tac Toe board and checking to see whether or not that position is occupied. If the user inputs that they would like to fill out position `2`, our `#position_taken?` method will check to see if that position is vacant or if it contains an "X" or and "O". If the position is free, the method should return `false` (i.e. "not taken"), otherwise it will return `true`. This method will also deal with 'user friendly' data (a String with a 1-9 number)
 
 #### `#valid_move?`
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ WIN_COMBINATIONS = [
 
 # the rest of the TicTacToe class definition
 ```
+**Note** The methods we will be decribing now have been defined in previous labs. You can copy those and paste them in this lab, and tweak them sightly to make them pass the tests.
 
 #### `#display_board`
 

--- a/spec/01_tic_tac_toe_spec.rb
+++ b/spec/01_tic_tac_toe_spec.rb
@@ -13,14 +13,14 @@ describe './lib/tic_tac_toe.rb' do
       it 'defines a constant WIN_COMBINATIONS with arrays for each win combination' do
         expect(TicTacToe::WIN_COMBINATIONS.size).to eq(8)
 
-        expect(TicTacToe::WIN_COMBINATIONS).to include([0,1,2])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([3,4,5])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([6,7,8])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([0,3,6])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([1,4,7])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([2,5,8])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([0,4,8])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([6,4,2])
+        expect(TicTacToe::WIN_COMBINATIONS).to include_array([0,1,2])
+        expect(TicTacToe::WIN_COMBINATIONS).to include_array([3,4,5])
+        expect(TicTacToe::WIN_COMBINATIONS).to include_array([6,7,8])
+        expect(TicTacToe::WIN_COMBINATIONS).to include_array([0,3,6])
+        expect(TicTacToe::WIN_COMBINATIONS).to include_array([1,4,7])
+        expect(TicTacToe::WIN_COMBINATIONS).to include_array([2,5,8])
+        expect(TicTacToe::WIN_COMBINATIONS).to include_array([0,4,8])
+        expect(TicTacToe::WIN_COMBINATIONS).to include_array([6,4,2])
       end
     end
 

--- a/spec/01_tic_tac_toe_spec.rb
+++ b/spec/01_tic_tac_toe_spec.rb
@@ -9,6 +9,21 @@ describe './lib/tic_tac_toe.rb' do
       end
     end
 
+    describe 'WIN_COMBINATIONS' do
+      it 'defines a constant WIN_COMBINATIONS with arrays for each win combination' do
+        expect(TicTacToe::WIN_COMBINATIONS.size).to eq(8)
+
+        expect(TicTacToe::WIN_COMBINATIONS).to include([0,1,2])
+        expect(TicTacToe::WIN_COMBINATIONS).to include([3,4,5])
+        expect(TicTacToe::WIN_COMBINATIONS).to include([6,7,8])
+        expect(TicTacToe::WIN_COMBINATIONS).to include([0,3,6])
+        expect(TicTacToe::WIN_COMBINATIONS).to include([1,4,7])
+        expect(TicTacToe::WIN_COMBINATIONS).to include([2,5,8])
+        expect(TicTacToe::WIN_COMBINATIONS).to include([0,4,8])
+        expect(TicTacToe::WIN_COMBINATIONS).to include([6,4,2])
+      end
+    end
+
     describe '#display_board' do
       it 'prints arbitrary arrangements of the board' do
         board = ["X", "X", "X", "X", "O", "O", "X", "O", "O"]
@@ -34,21 +49,6 @@ describe './lib/tic_tac_toe.rb' do
         expect(output).to include(" O | X | X ")
         expect(output).to include("-----------")
         expect(output).to include(" O | X | O ")
-      end
-    end
-
-    describe 'WIN_COMBINATIONS' do
-      it 'defines a constant WIN_COMBINATIONS with arrays for each win combination' do
-        expect(TicTacToe::WIN_COMBINATIONS.size).to eq(8)
-
-        expect(TicTacToe::WIN_COMBINATIONS).to include([0,1,2])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([3,4,5])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([6,7,8])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([0,3,6])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([1,4,7])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([2,5,8])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([0,4,8])
-        expect(TicTacToe::WIN_COMBINATIONS).to include([6,4,2])
       end
     end
 

--- a/spec/01_tic_tac_toe_spec.rb
+++ b/spec/01_tic_tac_toe_spec.rb
@@ -102,11 +102,11 @@ describe './lib/tic_tac_toe.rb' do
     end
 
     describe '#turn' do
-      it 'makes valid moves' do
+      it 'makes valid moves and displays the board' do
         game = TicTacToe.new
         allow($stdout).to receive(:puts)
-
         expect(game).to receive(:gets).and_return("1")
+        expect(game).to receive(:display_board)
 
         game.turn
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,12 @@ RSpec.configure do |config|
   config.order = :default
 end
 
+RSpec::Matchers.define :include_array do |expected|
+  match do |actual|
+    actual.any?{|array| match_array(expected).matches?(array)}
+  end
+end
+
 def run_file(file)
   eval(File.read(file), binding)
 end


### PR DESCRIPTION
The commits reflect the various issue being closed by each change but roughly:
1. Change the spec for WIN_COMBINATIONS to allow the combos in different orders fixes #18 fixes #11 
2. Add instruction to use previous methods from previous labs fixes #4 
3. Add test to check that user is calling `display_board` in the `turn` method fixes #19 
4. Change the  instructions for the `turn` method so that the `display_board` method is called _only_ when the move is valid, as opposed to the way it is now - where it would get displayed for as many wrong moves the user inputted.

I think that just about covers it 😃 
@PeterBell @AnnJohn 
