### PR TITLE
match #position_taken? tests to README behavior

### DIFF
--- a/spec/01_tic_tac_toe_spec.rb
+++ b/spec/01_tic_tac_toe_spec.rb
@@ -70,16 +70,16 @@ describe './lib/tic_tac_toe.rb' do
         board = ["X", " ", " ", " ", " ", " ", " ", " ", "O"]
         game.instance_variable_set(:@board, board)
 
-        position = 0
-        expect(game.position_taken?(position)).to be(true)
-
-        position = 8
-        expect(game.position_taken?(position)).to be(true)
-
         position = 1
+        expect(game.position_taken?(position)).to be(true)
+
+        position = 9
+        expect(game.position_taken?(position)).to be(true)
+
+        position = 2
         expect(game.position_taken?(position)).to be(false)
 
-        position = 7
+        position = 8
         expect(game.position_taken?(position)).to be(false)
       end
     end


### PR DESCRIPTION
Fixes https://github.com/learn-co-curriculum/oo-tic-tac-toe/issues/27

...but the implementation in each of the mentioned methods is still different from the previous TTT labs, which is confusing. It should be made obvious that these methods should take user input (1-9, as opposed to a plain index, 0-8) since the previous ones take a plain index.
